### PR TITLE
`getStatistic` is faster, `getSize` returns `false` is not statable

### DIFF
--- a/Generic.php
+++ b/Generic.php
@@ -88,6 +88,10 @@ abstract class Generic
      */
     public function getSize()
     {
+        if (false === $this->getStatistic()) {
+            return false;
+        }
+
         return filesize($this->getStreamName());
     }
 

--- a/Generic.php
+++ b/Generic.php
@@ -98,7 +98,7 @@ abstract class Generic
      */
     public function getStatistic()
     {
-        return stat($this->getStreamName());
+        return fstat($this->getStream());
     }
 
     /**


### PR DESCRIPTION
Fix #16.