### PR TITLE
Add glob support in the finder

### DIFF
--- a/Finder.php
+++ b/Finder.php
@@ -134,7 +134,20 @@ class Finder implements Iterator\Aggregate
         }
 
         foreach ($path as $p) {
-            $this->_paths[] = $p;
+            if (1 === preg_match('/[\*\?\[\]]/', $p)) {
+                $iterator = new Iterator\CallbackFilter(
+                    new Iterator\Glob(rtrim($p, DS)),
+                    function ($current) {
+                        return $current->isDir();
+                    }
+                );
+
+                foreach ($iterator as $path => $_fileInfo) {
+                    $this->_paths[] = $path;
+                }
+            } else {
+                $this->_paths[] = $p;
+            }
         }
 
         return $this;


### PR DESCRIPTION
Fix #18.

With that update if you specify a path like "/*emp" or "/{a,b,c}*.php", it will be processed nicely.

Example:
```php
<?php
$finder = (new Finder())->in(["/*emp", "/{a,b,c}*.php"]);
```

Does not use the `Iterator\Glob` implementation here because it does not have the GLOB_ONLYDIR filter. It can be replaced with a combination of `Iterator\CallbackFilter` and `Iterator\Glob` but it seems more complex which is not suitable here...