### PR TITLE
fix(directory) Use read-only mode when copying

### DIFF
--- a/Finder.php
+++ b/Finder.php
@@ -339,7 +339,6 @@ class Finder implements Iterator\Aggregate
         $filter = null;
 
         switch ($operator) {
-
             case '<':
                 $filter = function (\SplFileInfo $current) use ($number) {
                     return $current->getSize() < $number;


### PR DESCRIPTION
This is not possible to do `$file->open()->copy(); $file->close();` because the file will be opened in read and write mode. In a PHAR for instance, this operation is forbidden. So a special care must be taken to open file in read only mode.

See https://github.com/hoaproject/Kitab/issues/8.